### PR TITLE
Enables multiple opcodes

### DIFF
--- a/cmd/decodeasm/main.go
+++ b/cmd/decodeasm/main.go
@@ -54,9 +54,7 @@ func main() {
 	cp := capstone.NewCapstone(arch, mode)
 	defer cp.Close()
 	res := cp.Decode(opcode)
-	if len(res) != 1 {
-		fmt.Fprintf(flag.CommandLine.Output(), "expected 1 instruction, got %d\n", len(res))
-		os.Exit(1)
+	for _, d := range res {
+		fmt.Println(d)
 	}
-	fmt.Println(res[0])
 }

--- a/cmd/decodeasm/main.go
+++ b/cmd/decodeasm/main.go
@@ -54,6 +54,10 @@ func main() {
 	cp := capstone.NewCapstone(arch, mode)
 	defer cp.Close()
 	res := cp.Decode(opcode)
+	if len(res) == 0 {
+		fmt.Fprintf(flag.CommandLine.Output(), "expected at least 1 instruction, got %d\n", len(res))
+		os.Exit(1)
+	}
 	for _, d := range res {
 		fmt.Println(d)
 	}


### PR DESCRIPTION
```
$ decodeasm -arch=amd64 554889e5524883ec204889042448894c240848894808e80000000089442410488b0c24488b542408488951084889c84889d18b5c2410be05000000e80000000089442414488b0c24488951084889c84889d18b54241489d3e8000000004883c4205a4889ec5dc3
pushq %rbp
movq %rsp, %rbp
pushq %rdx
subq $0x20, %rsp
movq %rax, (%rsp)
movq %rcx, 8(%rsp)
movq %rcx, 8(%rax)
callq 0x730000001b
movl %eax, 0x10(%rsp)
movq (%rsp), %rcx
movq 8(%rsp), %rdx
movq %rdx, 8(%rcx)
movq %rcx, %rax
movq %rdx, %rcx
movl 0x10(%rsp), %ebx
movl $5, %esi
callq 0x7300000040
movl %eax, 0x14(%rsp)
movq (%rsp), %rcx
movq %rdx, 8(%rcx)
movq %rcx, %rax
movq %rdx, %rcx
movl 0x14(%rsp), %edx
movl %edx, %ebx
callq 0x730000005d
addq $0x20, %rsp
popq %rdx
movq %rbp, %rsp
popq %rbp
retq
```